### PR TITLE
Created questions entity and added relations

### DIFF
--- a/src/questions/questions.entity.ts
+++ b/src/questions/questions.entity.ts
@@ -1,0 +1,47 @@
+import { ItemEntity } from "src/items/items.entity";
+import { UserEntity } from "src/users/entities/user.entity";
+import { Column, CreateDateColumn, Entity, ManyToOne, OneToMany, OneToOne, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity()
+export class QuestionsEntity {
+
+    @PrimaryGeneratedColumn({
+        unsigned: true,
+        type: 'bigint'
+    })
+    id: number;
+
+    @ManyToOne(type => ItemEntity, item => item.questions)
+    item: ItemEntity;
+
+    @ManyToOne(type => UserEntity, user => user.questions)
+    user: UserEntity;
+
+    @Column({
+        name: 'question',
+        type: 'character varying',
+        nullable: false
+    })
+    questionContent: string;
+
+    @Column({
+        name: 'answer',
+        type: 'character varying',
+        nullable: true
+    })
+    answer: string;
+
+    @CreateDateColumn({
+        name: 'created_at',
+        type: 'timestamptz',
+        default: () => 'CURRENT_TIMESTAMP',
+    })
+    created_at : Date;
+
+    @UpdateDateColumn({
+        name: 'updated_at',
+        type: 'timestamptz',
+        default: () => 'CURRENT_TIMESTAMP',
+    })
+    updated_at : Date;
+}


### PR DESCRIPTION
## Linked Issue
#54 

## Changes
 - Created questions entity
 - Added relations for User & Item tables

## Comments
 - Items entity is not created at the time of making this pull request. Need to match shared properties (item.questions) when creating Item entity.
