### PR TITLE
2021 11 30 refactor platform behavior

### DIFF
--- a/src/platform/controllers/platform.controller.ts
+++ b/src/platform/controllers/platform.controller.ts
@@ -7,7 +7,6 @@ import {
   Param,
   Patch,
   Post,
-  Res,
   UsePipes,
   ValidationPipe,
 } from '@nestjs/common';
@@ -18,8 +17,6 @@ import {
   ApiBadRequestResponse,
   ApiParam,
 } from '@nestjs/swagger';
-import { Response } from 'express';
-import { User } from '../../users/entities/user.entity';
 import { CreatePlatformDTO } from '../create-platform-dto.entity';
 import { Platform } from '../platform.entity';
 
@@ -40,9 +37,7 @@ export class PlatformController {
   @Get()
   @HttpCode(200)
   findAll() {
-    return this.platformService.findAll().then((data) => {
-      return data;
-    });
+    return this.platformService.findAll();
   }
 
   @ApiOperation({ summary: 'Get a platform by id' })
@@ -58,21 +53,8 @@ export class PlatformController {
   })
   @Get(':id')
   @HttpCode(200)
-  findOne(
-    @Param('id') id: number | string,
-    @Res({ passthrough: true }) response: Response,
-  ) {
-    return this.platformService
-      .findOneById(id)
-      .then((data) => {
-        if (!data) {
-          response.status(400).end('Platform not found');
-        }
-        return data;
-      })
-      .catch((err) => {
-        response.status(400).end(err.message);
-      });
+  findOne(@Param('id') id: number | string) {
+    return this.platformService.findOneById(id);
   }
 
   @Post()
@@ -87,18 +69,8 @@ export class PlatformController {
   @ApiBadRequestResponse({
     description: 'The platform could not be created',
   })
-  async create(
-    @Body() createPlatform: CreatePlatformDTO,
-    @Res({ passthrough: true }) response: Response,
-  ) {
-    return this.platformService
-      .create(createPlatform)
-      .then(() => {
-        response.status(201).end('Platform created');
-      })
-      .catch((err) => {
-        response.status(400).end(err.message);
-      });
+  async create(@Body() createPlatform: CreatePlatformDTO) {
+    return this.platformService.create(createPlatform);
   }
 
   @Patch(':id')
@@ -120,23 +92,15 @@ export class PlatformController {
   update(
     @Param('id') id: string | number,
     @Body() updatePlatform: UpdatePlatformDTO,
-    @Res({ passthrough: true }) response: Response,
   ) {
-    return this.platformService
-      .update(id, updatePlatform)
-      .then(() => {
-        response.status(200).end('Platform updated');
-      })
-      .catch((err) => {
-        response.status(400).end(err.message);
-      });
+    return this.platformService.update(id, updatePlatform);
   }
 
   @Delete(':id')
   @HttpCode(204)
   @ApiOperation({ summary: 'Remove a platform' })
   @ApiResponse({
-    status: 200,
+    status: 204,
     description: 'The platform has been removed successfully.',
   })
   @ApiParam({
@@ -147,21 +111,7 @@ export class PlatformController {
   @ApiBadRequestResponse({
     description: 'The platform could not be removed',
   })
-  remove(
-    @Param('id') id: string,
-    @Res({ passthrough: true }) response: Response,
-  ) {
-    return this.platformService
-      .findOneById(id)
-      .then((data) => {
-        if (!data) {
-          response.status(400).end('Platform not found');
-        }
-        this.platformService.remove(parseInt(id));
-        response.status(200).end('Platform removed');
-      })
-      .catch((err) => {
-        response.status(400).end(err.message);
-      });
+  remove(@Param('id') id: string | number) {
+    return this.platformService.remove(id);
   }
 }

--- a/src/platform/controllers/platform.controller.ts
+++ b/src/platform/controllers/platform.controller.ts
@@ -8,6 +8,8 @@ import {
   Patch,
   Post,
   Res,
+  UsePipes,
+  ValidationPipe,
 } from '@nestjs/common';
 import {
   ApiOperation,
@@ -22,6 +24,7 @@ import { CreatePlatformDTO } from '../create-platform-dto.entity';
 import { Platform } from '../platform.entity';
 
 import { PlatformService } from '../services/platform.service';
+import { UpdatePlatformDTO } from '../update-platform-dto.entity';
 
 @ApiTags('Platforms')
 @Controller('platforms')
@@ -73,6 +76,7 @@ export class PlatformController {
   }
 
   @Post()
+  @UsePipes(new ValidationPipe({ transform: true }))
   @HttpCode(201)
   @ApiOperation({ summary: 'Create a platform' })
   @ApiResponse({
@@ -84,11 +88,11 @@ export class PlatformController {
     description: 'The platform could not be created',
   })
   async create(
-    @Body() createPlatformDTO: CreatePlatformDTO,
+    @Body() createPlatform: CreatePlatformDTO,
     @Res({ passthrough: true }) response: Response,
   ) {
     return this.platformService
-      .create(createPlatformDTO)
+      .create(createPlatform)
       .then(() => {
         response.status(201).end('Platform created');
       })
@@ -98,6 +102,7 @@ export class PlatformController {
   }
 
   @Patch(':id')
+  @UsePipes(new ValidationPipe({ transform: true }))
   @HttpCode(200)
   @ApiOperation({ summary: 'Update a platform' })
   @ApiResponse({
@@ -114,16 +119,12 @@ export class PlatformController {
   })
   update(
     @Param('id') id: string | number,
-    @Body() createPlatformDTO: CreatePlatformDTO,
+    @Body() updatePlatform: UpdatePlatformDTO,
     @Res({ passthrough: true }) response: Response,
   ) {
     return this.platformService
-      .findOneById(id)
-      .then((data) => {
-        if (!data) {
-          response.status(400).end('Platform not found');
-        }
-        this.platformService.update(id, createPlatformDTO);
+      .update(id, updatePlatform)
+      .then(() => {
         response.status(200).end('Platform updated');
       })
       .catch((err) => {

--- a/src/platform/create-platform-dto.entity.ts
+++ b/src/platform/create-platform-dto.entity.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsDate, IsInt } from 'class-validator';
+import { IsString, IsNotEmpty } from 'class-validator';
 
 export class CreatePlatformDTO {
   @ApiProperty({
@@ -7,6 +7,7 @@ export class CreatePlatformDTO {
     type: 'string',
   })
   @IsString()
+  @IsNotEmpty()
   countryCode: string;
 
   @ApiProperty({
@@ -14,6 +15,7 @@ export class CreatePlatformDTO {
     type: 'string',
   })
   @IsString()
+  @IsNotEmpty()
   currencyCode: string;
 
   @ApiProperty({
@@ -21,6 +23,7 @@ export class CreatePlatformDTO {
     type: 'string',
   })
   @IsString()
+  @IsNotEmpty()
   langCode: string;
 
   @ApiProperty({
@@ -28,5 +31,6 @@ export class CreatePlatformDTO {
     type: 'string',
   })
   @IsString()
+  @IsNotEmpty()
   phoneCountryCode: string;
 }

--- a/src/platform/create-platform-dto.entity.ts
+++ b/src/platform/create-platform-dto.entity.ts
@@ -3,24 +3,6 @@ import { IsString, IsDate, IsInt } from 'class-validator';
 
 export class CreatePlatformDTO {
   @ApiProperty({
-    description: 'The date when the platform is created',
-    default: 'Current date',
-    type: 'date',
-    format: 'date-time',
-  })
-  @IsDate()
-  createdAt: Date;
-
-  @ApiProperty({
-    description: 'The date when the platform is updated',
-    default: 'Current date',
-    type: 'date',
-    format: 'date-time',
-  })
-  @IsDate()
-  updatedAt: Date;
-
-  @ApiProperty({
     description: '3 digits ISO country code (Example: ARG)',
     type: 'string',
   })

--- a/src/platform/platform.entity.ts
+++ b/src/platform/platform.entity.ts
@@ -14,6 +14,7 @@ export class Platform {
   @ApiProperty({
     description: 'Platform Id number',
     type: 'integer',
+    example: 1,
   })
   @PrimaryGeneratedColumn({
     unsigned: true,
@@ -26,6 +27,7 @@ export class Platform {
     default: 'Current date',
     type: 'date',
     format: 'date-time',
+    example: Date.now(),
   })
   @CreateDateColumn({
     name: 'created_at',
@@ -39,6 +41,7 @@ export class Platform {
     default: 'Current date',
     type: 'date',
     format: 'date-time',
+    example: Date.now(),
   })
   @UpdateDateColumn({
     name: 'updated_at',
@@ -48,8 +51,23 @@ export class Platform {
   updatedAt: Date;
 
   @ApiProperty({
-    description: '3 digits ISO country code (Example: ARG)',
+    description: 'The date when the platform has been soft deleted',
+    default: null,
+    type: 'date',
+    format: 'date-time',
+    example: Date.now(),
+  })
+  @UpdateDateColumn({
+    name: 'removed_at',
+    type: 'timestamptz',
+    default: () => null,
+  })
+  removedAt: Date;
+
+  @ApiProperty({
+    description: '3 digits ISO country code',
     type: 'string',
+    example: 'ARG',
   })
   @Column({
     name: 'country_code',
@@ -59,8 +77,9 @@ export class Platform {
   countryCode: string;
 
   @ApiProperty({
-    description: '3 digits ISO currency code (Example: ARS)',
+    description: '3 digits ISO currency code',
     type: 'string',
+    example: 'ARG',
   })
   @Column({
     name: 'currency_code',
@@ -70,8 +89,9 @@ export class Platform {
   currencyCode: string;
 
   @ApiProperty({
-    description: '5 digits ISO language code (Example: es_AR)',
+    description: '5 digits ISO language code',
     type: 'string',
+    example: 'es_AR',
   })
   @Column({
     name: 'lang_code',
@@ -81,8 +101,9 @@ export class Platform {
   langCode: string;
 
   @ApiProperty({
-    description: 'Up to 5 digits phone code (Example: ++549)',
+    description: 'Up to 5 digits phone code',
     type: 'string',
+    example: '++549',
   })
   @Column({
     name: 'phone_country_code',

--- a/src/platform/services/platform.service.ts
+++ b/src/platform/services/platform.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { DeleteResult, Repository, UpdateResult } from 'typeorm';
 import { CreatePlatformDTO } from '../create-platform-dto.entity';
 import { Platform } from '../platform.entity';
+import { UpdatePlatformDTO } from '../update-platform-dto.entity';
 
 @Injectable()
 export class PlatformService {
@@ -20,17 +21,40 @@ export class PlatformService {
   }
 
   async create(platform: CreatePlatformDTO): Promise<Platform> {
+    if (await this.exists(platform)) {
+      throw new Error('The platform already exists');
+    }
     return this.platformRepository.save(platform);
   }
 
   async update(
     id: number | string,
-    platform: CreatePlatformDTO,
+    platform: UpdatePlatformDTO,
   ): Promise<UpdateResult> {
+    if (!(await this.findOneById(id))) {
+      throw new Error('Platform not found');
+    }
+    const foundId = await this.exists(platform);
+    if (foundId && (await this.exists(platform)) != id) {
+      throw new Error(
+        'This modification will produce two platforms with the same attributes',
+      );
+    }
+    platform.updatedAt = new Date();
     return this.platformRepository.update(id, platform);
   }
 
   async remove(id: number): Promise<DeleteResult> {
     return this.platformRepository.delete(id);
+  }
+
+  async exists(
+    platform: CreatePlatformDTO | UpdatePlatformDTO,
+  ): Promise<number | null> {
+    const foundPlatform = await this.platformRepository.findOne(platform);
+    if (foundPlatform) {
+      return foundPlatform.id;
+    }
+    return null;
   }
 }

--- a/src/platform/services/platform.service.ts
+++ b/src/platform/services/platform.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DeleteResult, Repository, UpdateResult } from 'typeorm';
+import { Repository } from 'typeorm';
 import { CreatePlatformDTO } from '../create-platform-dto.entity';
 import { Platform } from '../platform.entity';
 import { UpdatePlatformDTO } from '../update-platform-dto.entity';

--- a/src/platform/update-platform-dto.entity.ts
+++ b/src/platform/update-platform-dto.entity.ts
@@ -1,0 +1,45 @@
+import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+import { UpdateDateColumn } from 'typeorm';
+
+export class UpdatePlatformDTO {
+  @ApiHideProperty()
+  @UpdateDateColumn({
+    name: 'updated_at',
+    type: 'timestamptz',
+    default: () => 'CURRENT_TIMESTAMP',
+  })
+  updatedAt: Date;
+
+  @ApiProperty({
+    description: '3 digits ISO country code (Example: ARG)',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  countryCode: string;
+
+  @ApiProperty({
+    description: '3 digits ISO currency code (Example: ARS)',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  currencyCode: string;
+
+  @ApiProperty({
+    description: '5 digits ISO language code (Example: es_AR)',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  langCode: string;
+
+  @ApiProperty({
+    description: 'Up to 5 digits phone code (Example: ++549)',
+    type: 'string',
+  })
+  @IsString()
+  @IsNotEmpty()
+  phoneCountryCode: string;
+}


### PR DESCRIPTION
## Attention! - It´s being compared, against branch 2021-11-26-refactoring-documentation (not against main)

* Remove createdAt and updatedAt from CreatePlatformDTO as this is no data the client should modify.
* Add IsNotEmpty decorator for validation pipe to the DTO´s.
* Create UpdatePlatformDTO to add updatedAt date (in comparisson to CreatePlatformDTO).
* Add pipes to platform create and update methods for validation in the controller.
* Add validations during creation and updating in the service.

### Evidence:
![image](https://user-images.githubusercontent.com/18199281/144044728-4b6957f7-aee7-4d12-86e6-9a86dfa6fc88.png)
![image](https://user-images.githubusercontent.com/18199281/144044854-0c968be5-51f1-4502-bddc-310a2c5726f8.png)
![image](https://user-images.githubusercontent.com/18199281/144044870-7e347135-1611-415a-8aa7-cdfbf22b6019.png)
![image](https://user-images.githubusercontent.com/18199281/144044940-c2d4f9bf-f494-4908-89d7-f85038d329d4.png)
![image](https://user-images.githubusercontent.com/18199281/144044965-576fea69-bb78-4f40-9c9b-431f82d13d47.png)
![image](https://user-images.githubusercontent.com/18199281/144045088-2ec8c729-bcda-4441-8438-4d293ffc7f94.png)
![image](https://user-images.githubusercontent.com/18199281/144045510-22f22f5b-bdcd-47c3-88f0-98e45b60c4ea.png)

