### PR TITLE
Auth items

### DIFF
--- a/src/auth/casl/casl-ability.factory.ts
+++ b/src/auth/casl/casl-ability.factory.ts
@@ -8,9 +8,10 @@ import {
 import { Injectable } from '@nestjs/common';
 import { Permission } from '../permission.enum';
 import { User } from '../../users/entities/user.entity';
+import { Item } from '../../items/entities/items.entity';
 
-// TODO: replace any with classes
-type Subjects = InferSubjects<any> | 'all';
+// TODO: add classes to InferSubjects -> InferSubjects<typeof Item | typeof Review ...>
+type Subjects = InferSubjects<typeof Item> | 'all';
 
 export type AppAbility = Ability<[Permission, Subjects]>;
 
@@ -20,6 +21,9 @@ export class CaslAbilityFactory {
     const { can, cannot, build } = new AbilityBuilder<
       Ability<[Permission, Subjects]>
     >(Ability as AbilityClass<AppAbility>);
+
+    can([Permission.Create, Permission.Read], Item);
+    can([Permission.Delete, Permission.Update], Item, { userId: user.id });
 
     return build({
       // Read https://casl.js.org/v5/en/guide/subject-type-detection#use-classes-as-subject-types for details

--- a/src/items/controllers/items.controller.spec.ts
+++ b/src/items/controllers/items.controller.spec.ts
@@ -1,18 +1,237 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { request, response } from 'express';
+
+import { CaslModule } from '../../auth/casl/casl.module';
+import { Brand } from '../../brands/entities/brands.entity';
+import { Category } from '../../categories/categories.entity';
+import { User } from '../../users/entities/user.entity';
+
+import { CreateItemDTO } from '../entities/create.item.dto';
+
+import { ItemsService } from '../services/items.service';
 import { ItemsController } from './items.controller';
 
 describe('ItemsController', () => {
   let controller: ItemsController;
+  const newUser = new User();
+  newUser.id = 1;
+
+  const mockItemsService = {
+    findAll: jest.fn().mockImplementation(() => Promise.resolve([{
+      id: 2,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: "Name",
+      description: "Des",
+      price: 1,
+      stock: 1,
+      brandId: 1,
+      userId: 1,
+      categoryId: 1,
+      cartItemsId: 1,
+      questions: []
+    }, {
+      id: 3,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: "Name 2",
+      description: "Des 2",
+      price: 2,
+      stock: 2,
+      brandId: 2,
+      userId: newUser.id,
+      categoryId: 2,
+      cartItemsId: 2,
+      questions: []
+    }])),
+    findOne: jest.fn().mockImplementation((id) => Promise.resolve({
+      id: 3,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: "Name 2",
+      description: "Des 2",
+      price: 2,
+      stock: 2,
+      brandId: 2,
+      userId: newUser.id,
+      categoryId: 2,
+      cartItemsId: 2,
+      questions: []
+    })),
+    create: jest.fn().mockImplementation((user, body) => {
+      Object.assign(body, { id: 4, userId: user.id })
+      return Promise.resolve(body)
+    }),
+    update: jest.fn().mockImplementation((user, id, body) => {
+      return Promise.resolve({
+        ...({
+          id: id,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          title: "Name 2",
+          description: "Des 2",
+          price: 2,
+          stock: 2,
+          brandId: 2,
+          userId: user.id,
+          categoryId: 2,
+          cartItemsId: 2,
+          questions: []
+        }),
+        ...body
+      })
+    }),
+    delete: jest.fn().mockImplementation((user, id) => true),
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ItemsController],
-    }).compile();
+      providers: [ItemsService],
+      imports: [CaslModule]
+    })
+      .overrideProvider(ItemsService)
+      .useValue(mockItemsService)
+      .compile();
 
     controller = module.get<ItemsController>(ItemsController);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+
+  describe('all', () => {
+    it('should return an array of Items', async () => {
+      expect(await controller.getAll()).toEqual([{
+        id: 2,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name",
+        description: "Des",
+        price: 1,
+        stock: 1,
+        brandId: 1,
+        userId: 1,
+        categoryId: 1,
+        cartItemsId: 1,
+        questions: []
+      }, {
+        id: 3,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: 2,
+        userId: newUser.id,
+        categoryId: 2,
+        cartItemsId: 2,
+        questions: []
+      }]);
+    });
+  });
+
+  describe('one', () => {
+    it('should return an Item', async () => {
+      expect(await controller.getOne(request, 3, response)).toEqual({
+        id: 3,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: 2,
+        userId: newUser.id,
+        categoryId: 2,
+        cartItemsId: 2,
+        questions: []
+      });
+    });
+
+    it('should return a NotFoundError message', async () => {
+      mockItemsService.findOne.mockImplementationOnce(() => { throw new HttpException('Not Found', HttpStatus.NOT_FOUND); });
+
+      expect(await controller.getOne(request, 10, response)).toEqual("Not Found");
+    });
+  });
+
+  describe('create', () => {
+    it('should create a Item', async () => {
+      const dto: CreateItemDTO = {
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: new Brand,
+        categoryId: new Category,
+      };
+
+      expect(await controller.create(request, dto)).toEqual({
+        id: 4,
+        ...dto,
+        userId: newUser.id
+      });
+
+      expect(mockItemsService.create).toHaveBeenCalledWith(expect.any(User), dto);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an Item', async () => {
+      const item = {
+        id: 3,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: 2,
+        userId: newUser.id,
+        categoryId: 2,
+        cartItemsId: 2,
+        questions: []
+      }
+
+      const dto = {
+        price: 100,
+        stock: 500
+      };
+
+      expect(await controller.update(request, item.id, dto, response)).toEqual({ ...item, price: 100, stock: 500 });
+
+      expect(mockItemsService.update).toHaveBeenCalledWith(expect.any(User), item.id, dto);
+    });
+
+    it('should return ForbiddenError message', async () => {
+      mockItemsService.update.mockImplementationOnce(() => { throw new HttpException('Forbidden', HttpStatus.FORBIDDEN); });
+      const dto = {
+        stock: 500
+      };
+
+      expect(await controller.update(request, newUser.id + 1, dto, response)).toEqual("Forbidden");
+
+      expect(mockItemsService.update).toHaveBeenCalledWith(expect.any(User), newUser.id + 1, dto);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an Item', async () => {
+      expect(await controller.delete(request, 10, response)).toEqual(true);
+
+      expect(mockItemsService.delete).toHaveBeenCalledWith(expect.any(User), 10);
+    });
+
+    it('should return ForbiddenError message', async () => {
+      mockItemsService.delete.mockImplementationOnce(() => { throw new HttpException('Forbidden', HttpStatus.FORBIDDEN); });
+      expect(await controller.delete(request, 10, response)).toEqual("Forbidden");
+
+      expect(mockItemsService.delete).toHaveBeenCalledWith(expect.any(User), 10);
+    });
   });
 });

--- a/src/items/controllers/items.controller.spec.ts
+++ b/src/items/controllers/items.controller.spec.ts
@@ -18,78 +18,85 @@ describe('ItemsController', () => {
   newUser.id = 1;
 
   const mockItemsService = {
-    findAll: jest.fn().mockImplementation(() => Promise.resolve([{
-      id: 2,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      title: "Name",
-      description: "Des",
-      price: 1,
-      stock: 1,
-      brandId: 1,
-      userId: 1,
-      categoryId: 1,
-      cartItemsId: 1,
-      questions: []
-    }, {
-      id: 3,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      title: "Name 2",
-      description: "Des 2",
-      price: 2,
-      stock: 2,
-      brandId: 2,
-      userId: newUser.id,
-      categoryId: 2,
-      cartItemsId: 2,
-      questions: []
-    }])),
-    findOne: jest.fn().mockImplementation((id) => Promise.resolve({
-      id: 3,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      title: "Name 2",
-      description: "Des 2",
-      price: 2,
-      stock: 2,
-      brandId: 2,
-      userId: newUser.id,
-      categoryId: 2,
-      cartItemsId: 2,
-      questions: []
-    })),
+    findAll: jest.fn().mockImplementation(() =>
+      Promise.resolve([
+        {
+          id: 2,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          title: 'Name',
+          description: 'Des',
+          price: 1,
+          stock: 1,
+          brandId: 1,
+          userId: 1,
+          categoryId: 1,
+          cartItemsId: 1,
+          questions: [],
+        },
+        {
+          id: 3,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          title: 'Name 2',
+          description: 'Des 2',
+          price: 2,
+          stock: 2,
+          brandId: 2,
+          userId: newUser.id,
+          categoryId: 2,
+          cartItemsId: 2,
+          questions: [],
+        },
+      ]),
+    ),
+    findOne: jest.fn().mockImplementation((id) =>
+      Promise.resolve({
+        id: 3,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        title: 'Name 2',
+        description: 'Des 2',
+        price: 2,
+        stock: 2,
+        brandId: 2,
+        userId: newUser.id,
+        categoryId: 2,
+        cartItemsId: 2,
+        questions: [],
+      }),
+    ),
     create: jest.fn().mockImplementation((user, body) => {
-      Object.assign(body, { id: 4, userId: user.id })
-      return Promise.resolve(body)
+      Object.assign(body, { id: 4, userId: user.id });
+      return Promise.resolve(body);
     }),
     update: jest.fn().mockImplementation((user, id, body) => {
       return Promise.resolve({
-        ...({
+        ...{
           id: id,
           createdAt: new Date(),
           updatedAt: new Date(),
-          title: "Name 2",
-          description: "Des 2",
+          title: 'Name 2',
+          description: 'Des 2',
           price: 2,
           stock: 2,
           brandId: 2,
           userId: user.id,
           categoryId: 2,
           cartItemsId: 2,
-          questions: []
-        }),
-        ...body
-      })
+          questions: [],
+        },
+        ...body,
+      });
     }),
     delete: jest.fn().mockImplementation((user, id) => true),
-  }
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ItemsController],
       providers: [ItemsService],
-      imports: [CaslModule]
+      imports: [CaslModule],
     })
       .overrideProvider(ItemsService)
       .useValue(mockItemsService)
@@ -102,36 +109,38 @@ describe('ItemsController', () => {
     expect(controller).toBeDefined();
   });
 
-
   describe('all', () => {
     it('should return an array of Items', async () => {
-      expect(await controller.getAll()).toEqual([{
-        id: 2,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        title: "Name",
-        description: "Des",
-        price: 1,
-        stock: 1,
-        brandId: 1,
-        userId: 1,
-        categoryId: 1,
-        cartItemsId: 1,
-        questions: []
-      }, {
-        id: 3,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        title: "Name 2",
-        description: "Des 2",
-        price: 2,
-        stock: 2,
-        brandId: 2,
-        userId: newUser.id,
-        categoryId: 2,
-        cartItemsId: 2,
-        questions: []
-      }]);
+      expect(await controller.getAll()).toEqual([
+        {
+          id: 2,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          title: 'Name',
+          description: 'Des',
+          price: 1,
+          stock: 1,
+          brandId: 1,
+          userId: 1,
+          categoryId: 1,
+          cartItemsId: 1,
+          questions: [],
+        },
+        {
+          id: 3,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          title: 'Name 2',
+          description: 'Des 2',
+          price: 2,
+          stock: 2,
+          brandId: 2,
+          userId: newUser.id,
+          categoryId: 2,
+          cartItemsId: 2,
+          questions: [],
+        },
+      ]);
     });
   });
 
@@ -141,43 +150,50 @@ describe('ItemsController', () => {
         id: 3,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
-        title: "Name 2",
-        description: "Des 2",
+        title: 'Name 2',
+        description: 'Des 2',
         price: 2,
         stock: 2,
         brandId: 2,
         userId: newUser.id,
         categoryId: 2,
         cartItemsId: 2,
-        questions: []
+        questions: [],
       });
     });
 
     it('should return a NotFoundError message', async () => {
-      mockItemsService.findOne.mockImplementationOnce(() => { throw new HttpException('Not Found', HttpStatus.NOT_FOUND); });
+      mockItemsService.findOne.mockImplementationOnce(() => {
+        throw new HttpException('Not Found', HttpStatus.NOT_FOUND);
+      });
 
-      expect(await controller.getOne(request, 10, response)).toEqual("Not Found");
+      expect(await controller.getOne(request, 10, response)).toEqual(
+        'Not Found',
+      );
     });
   });
 
   describe('create', () => {
     it('should create a Item', async () => {
       const dto: CreateItemDTO = {
-        title: "Name 2",
-        description: "Des 2",
+        title: 'Name 2',
+        description: 'Des 2',
         price: 2,
         stock: 2,
-        brandId: new Brand,
-        categoryId: new Category,
+        brandId: new Brand(),
+        categoryId: new Category(),
       };
 
       expect(await controller.create(request, dto)).toEqual({
         id: 4,
         ...dto,
-        userId: newUser.id
+        userId: newUser.id,
       });
 
-      expect(mockItemsService.create).toHaveBeenCalledWith(expect.any(User), dto);
+      expect(mockItemsService.create).toHaveBeenCalledWith(
+        expect.any(User),
+        dto,
+      );
     });
   });
 
@@ -187,36 +203,52 @@ describe('ItemsController', () => {
         id: 3,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
-        title: "Name 2",
-        description: "Des 2",
+        title: 'Name 2',
+        description: 'Des 2',
         price: 2,
         stock: 2,
         brandId: 2,
         userId: newUser.id,
         categoryId: 2,
         cartItemsId: 2,
-        questions: []
-      }
+        questions: [],
+      };
 
       const dto = {
         price: 100,
-        stock: 500
+        stock: 500,
       };
 
-      expect(await controller.update(request, item.id, dto, response)).toEqual({ ...item, price: 100, stock: 500 });
+      expect(await controller.update(request, item.id, dto, response)).toEqual({
+        ...item,
+        price: 100,
+        stock: 500,
+      });
 
-      expect(mockItemsService.update).toHaveBeenCalledWith(expect.any(User), item.id, dto);
+      expect(mockItemsService.update).toHaveBeenCalledWith(
+        expect.any(User),
+        item.id,
+        dto,
+      );
     });
 
     it('should return ForbiddenError message', async () => {
-      mockItemsService.update.mockImplementationOnce(() => { throw new HttpException('Forbidden', HttpStatus.FORBIDDEN); });
+      mockItemsService.update.mockImplementationOnce(() => {
+        throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+      });
       const dto = {
-        stock: 500
+        stock: 500,
       };
 
-      expect(await controller.update(request, newUser.id + 1, dto, response)).toEqual("Forbidden");
+      expect(
+        await controller.update(request, newUser.id + 1, dto, response),
+      ).toEqual('Forbidden');
 
-      expect(mockItemsService.update).toHaveBeenCalledWith(expect.any(User), newUser.id + 1, dto);
+      expect(mockItemsService.update).toHaveBeenCalledWith(
+        expect.any(User),
+        newUser.id + 1,
+        dto,
+      );
     });
   });
 
@@ -224,14 +256,24 @@ describe('ItemsController', () => {
     it('should remove an Item', async () => {
       expect(await controller.delete(request, 10, response)).toEqual(true);
 
-      expect(mockItemsService.delete).toHaveBeenCalledWith(expect.any(User), 10);
+      expect(mockItemsService.delete).toHaveBeenCalledWith(
+        expect.any(User),
+        10,
+      );
     });
 
     it('should return ForbiddenError message', async () => {
-      mockItemsService.delete.mockImplementationOnce(() => { throw new HttpException('Forbidden', HttpStatus.FORBIDDEN); });
-      expect(await controller.delete(request, 10, response)).toEqual("Forbidden");
+      mockItemsService.delete.mockImplementationOnce(() => {
+        throw new HttpException('Forbidden', HttpStatus.FORBIDDEN);
+      });
+      expect(await controller.delete(request, 10, response)).toEqual(
+        'Forbidden',
+      );
 
-      expect(mockItemsService.delete).toHaveBeenCalledWith(expect.any(User), 10);
+      expect(mockItemsService.delete).toHaveBeenCalledWith(
+        expect.any(User),
+        10,
+      );
     });
   });
 });

--- a/src/items/controllers/items.controller.ts
+++ b/src/items/controllers/items.controller.ts
@@ -1,4 +1,16 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Patch, Post, Req, Res, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  Patch,
+  Post,
+  Req,
+  Res,
+  UseGuards,
+} from '@nestjs/common';
 import { ItemsService } from '../services/items.service';
 import { Item } from '../entities/items.entity';
 
@@ -12,10 +24,10 @@ import { PoliciesGuard } from '../../auth/guards/policies.guard';
 import { Request, Response } from 'express';
 import { User } from '../../users/entities/user.entity';
 
-@ApiTags("Items")
+@ApiTags('Items')
 @Controller('items')
 export class ItemsController {
-  constructor(private readonly ItemsService: ItemsService) { }
+  constructor(private readonly ItemsService: ItemsService) {}
 
   @ApiOperation({ summary: 'Get all items' })
   @ApiResponse({
@@ -37,7 +49,11 @@ export class ItemsController {
   })
   @Get(':id')
   @HttpCode(200)
-  getOne(@Req() req: Request, @Param('id') id: number, @Res() res: Response): Promise<Item> {
+  getOne(
+    @Req() req: Request,
+    @Param('id') id: number,
+    @Res() res: Response,
+  ): Promise<Item> {
     try {
       return this.ItemsService.findOne(id);
     } catch (error) {
@@ -77,7 +93,12 @@ export class ItemsController {
   @Patch(':id')
   @UseGuards(PoliciesGuard)
   @HttpCode(204)
-  update(@Req() req: Request, @Param('id') id: number, @Body() body: any, @Res() res: Response): Promise<Item> {
+  update(
+    @Req() req: Request,
+    @Param('id') id: number,
+    @Body() body: any,
+    @Res() res: Response,
+  ): Promise<Item> {
     const user = new User();
     user.id = 1;
 
@@ -101,7 +122,11 @@ export class ItemsController {
   @Delete(':id')
   @UseGuards(PoliciesGuard)
   @HttpCode(200)
-  delete(@Req() req: Request, @Param('id') id: number, @Res() res: Response): Promise<boolean> {
+  delete(
+    @Req() req: Request,
+    @Param('id') id: number,
+    @Res() res: Response,
+  ): Promise<boolean> {
     const user = new User();
     user.id = 1;
 

--- a/src/items/entities/create.item.dto.ts
+++ b/src/items/entities/create.item.dto.ts
@@ -1,5 +1,5 @@
-import { Brand } from "../../brands/entities/brands.entity";
-import { Category } from "../../categories/categories.entity";
+import { Brand } from '../../brands/entities/brands.entity';
+import { Category } from '../../categories/categories.entity';
 
 export class CreateItemDTO {
   title: string;
@@ -7,6 +7,5 @@ export class CreateItemDTO {
   price: number;
   stock: number;
   brandId: Brand;
-  categoryId: Category
+  categoryId: Category;
 }
-

--- a/src/items/entities/create.item.dto.ts
+++ b/src/items/entities/create.item.dto.ts
@@ -1,0 +1,12 @@
+import { Brand } from "../../brands/entities/brands.entity";
+import { Category } from "../../categories/categories.entity";
+
+export class CreateItemDTO {
+  title: string;
+  description: string;
+  price: number;
+  stock: number;
+  brandId: Brand;
+  categoryId: Category
+}
+

--- a/src/items/entities/items.entity.ts
+++ b/src/items/entities/items.entity.ts
@@ -16,7 +16,6 @@ import { Category } from '../../categories/categories.entity';
 import { CartItem } from '../../cart-item/entities/cart-item.entity';
 import { Question } from '../../questions/entities/question.entity';
 
-
 @Entity('items')
 export class Item {
   @PrimaryGeneratedColumn({
@@ -88,7 +87,7 @@ export class Item {
   @ApiProperty({ example: 10, description: 'Id of the Item Brand' })
   brandId: Brand;
 
-  @ManyToOne(() => User, user => user.items)
+  @ManyToOne(() => User, (user) => user.items)
   @JoinColumn({
     name: 'user_id',
   })

--- a/src/items/items.module.ts
+++ b/src/items/items.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CaslModule } from '../auth/casl/casl.module';
 import { ItemsController } from './controllers/items.controller';
 import { Item } from './entities/items.entity';
 import { ItemsService } from './services/items.service';
@@ -8,7 +9,8 @@ import { ItemsService } from './services/items.service';
   controllers: [ItemsController],
   providers: [ItemsService],
   imports: [
-    TypeOrmModule.forFeature([Item])
+    TypeOrmModule.forFeature([Item]),
+    CaslModule
   ]
 })
 export class ItemsModule { }

--- a/src/items/items.module.ts
+++ b/src/items/items.module.ts
@@ -8,9 +8,6 @@ import { ItemsService } from './services/items.service';
 @Module({
   controllers: [ItemsController],
   providers: [ItemsService],
-  imports: [
-    TypeOrmModule.forFeature([Item]),
-    CaslModule
-  ]
+  imports: [TypeOrmModule.forFeature([Item]), CaslModule],
 })
-export class ItemsModule { }
+export class ItemsModule {}

--- a/src/items/services/items.service.spec.ts
+++ b/src/items/services/items.service.spec.ts
@@ -19,51 +19,56 @@ describe('ItemsService', () => {
     id: 3,
     createdAt: new Date(),
     updatedAt: new Date(),
-    title: "Name 2",
-    description: "Des 2",
+    title: 'Name 2',
+    description: 'Des 2',
     price: 2,
     stock: 2,
     brandId: new Brand(),
     userId,
     categoryId: new Category(),
     cartItemsId: [],
-    questions: []
-  }
+    questions: [],
+  };
 
   const mockItemsRepository = {
-    find: jest.fn(() => Promise.resolve([{
-      id: 2,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      title: "Name",
-      description: "Des",
-      price: 1,
-      stock: 1,
-      brandId: new Brand(),
-      userId: 1,
-      categoryId: new Category(),
-      cartItemsId: [],
-      questions: []
-    }, {
-      id: 3,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-      title: "Name 2",
-      description: "Des 2",
-      price: 2,
-      stock: 2,
-      brandId: new Brand(),
-      userId: newUser.id,
-      categoryId: new Category(),
-      cartItemsId: [],
-      questions: []
-    }])),
-    findOne: jest.fn(id => Promise.resolve(genericItem)),
-    create: jest.fn(body => Object.assign(body, { id: 4 })),
+    find: jest.fn(() =>
+      Promise.resolve([
+        {
+          id: 2,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          title: 'Name',
+          description: 'Des',
+          price: 1,
+          stock: 1,
+          brandId: new Brand(),
+          userId: 1,
+          categoryId: new Category(),
+          cartItemsId: [],
+          questions: [],
+        },
+        {
+          id: 3,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          title: 'Name 2',
+          description: 'Des 2',
+          price: 2,
+          stock: 2,
+          brandId: new Brand(),
+          userId: newUser.id,
+          categoryId: new Category(),
+          cartItemsId: [],
+          questions: [],
+        },
+      ]),
+    ),
+    findOne: jest.fn((id) => Promise.resolve(genericItem)),
+    create: jest.fn((body) => Object.assign(body, { id: 4 })),
     merge: jest.fn((item, body) => Object.assign({ item, body })),
-    save: jest.fn(item => Promise.resolve(item)),
-    delete: jest.fn(id => Promise.resolve(true)),
-  }
+    save: jest.fn((item) => Promise.resolve(item)),
+    delete: jest.fn((id) => Promise.resolve(true)),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -73,10 +78,9 @@ describe('ItemsService', () => {
           provide: getRepositoryToken(Item),
           useValue: mockItemsRepository,
         },
-        CaslAbilityFactory
-      ]
-    })
-      .compile();
+        CaslAbilityFactory,
+      ],
+    }).compile();
 
     service = module.get<ItemsService>(ItemsService);
   });
@@ -87,33 +91,36 @@ describe('ItemsService', () => {
 
   describe('all', () => {
     it('should return an array of Items', async () => {
-      expect(await service.findAll()).toEqual([{
-        id: 2,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        title: "Name",
-        description: "Des",
-        price: 1,
-        stock: 1,
-        brandId: expect.any(Brand),
-        userId: 1,
-        categoryId: expect.any(Category),
-        cartItemsId: [],
-        questions: []
-      }, {
-        id: 3,
-        createdAt: expect.any(Date),
-        updatedAt: expect.any(Date),
-        title: "Name 2",
-        description: "Des 2",
-        price: 2,
-        stock: 2,
-        brandId: expect.any(Brand),
-        userId: newUser.id,
-        categoryId: expect.any(Category),
-        cartItemsId: [],
-        questions: []
-      }]);
+      expect(await service.findAll()).toEqual([
+        {
+          id: 2,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          title: 'Name',
+          description: 'Des',
+          price: 1,
+          stock: 1,
+          brandId: expect.any(Brand),
+          userId: 1,
+          categoryId: expect.any(Category),
+          cartItemsId: [],
+          questions: [],
+        },
+        {
+          id: 3,
+          createdAt: expect.any(Date),
+          updatedAt: expect.any(Date),
+          title: 'Name 2',
+          description: 'Des 2',
+          price: 2,
+          stock: 2,
+          brandId: expect.any(Brand),
+          userId: newUser.id,
+          categoryId: expect.any(Category),
+          cartItemsId: [],
+          questions: [],
+        },
+      ]);
     });
   });
 
@@ -123,15 +130,15 @@ describe('ItemsService', () => {
         id: 3,
         createdAt: expect.any(Date),
         updatedAt: expect.any(Date),
-        title: "Name 2",
-        description: "Des 2",
+        title: 'Name 2',
+        description: 'Des 2',
         price: 2,
         stock: 2,
         brandId: expect.any(Brand),
         userId: newUser.id,
         categoryId: expect.any(Category),
         cartItemsId: [],
-        questions: []
+        questions: [],
       });
     });
 
@@ -149,8 +156,8 @@ describe('ItemsService', () => {
   describe('create', () => {
     it('should create a Item', async () => {
       const dto: CreateItemDTO = {
-        title: "Name 2",
-        description: "Des 2",
+        title: 'Name 2',
+        description: 'Des 2',
         price: 2,
         stock: 2,
         brandId: new Brand(),
@@ -160,7 +167,7 @@ describe('ItemsService', () => {
       const expected = {
         id: 4,
         ...dto,
-        userId: newUser.id
+        userId: newUser.id,
       };
 
       expect(await service.create(newUser, dto)).toEqual(expected);
@@ -175,7 +182,7 @@ describe('ItemsService', () => {
       newUser.id = userId;
       const dto = {
         price: 100,
-        stock: 500
+        stock: 500,
       };
 
       const expected = {
@@ -185,9 +192,13 @@ describe('ItemsService', () => {
         updatedAt: expect.any(Date),
       };
 
-      mockItemsRepository.save.mockReturnValueOnce(Promise.resolve({ ...genericItem, ...dto }));
+      mockItemsRepository.save.mockReturnValueOnce(
+        Promise.resolve({ ...genericItem, ...dto }),
+      );
 
-      expect(await service.update(newUser, genericItem.id, dto)).toEqual(expected);
+      expect(await service.update(newUser, genericItem.id, dto)).toEqual(
+        expected,
+      );
 
       expect(mockItemsRepository.findOne).toHaveBeenCalledWith(genericItem.id);
       expect(mockItemsRepository.merge).toHaveBeenCalledWith(genericItem, dto);
@@ -196,11 +207,13 @@ describe('ItemsService', () => {
     it('should throw ForbiddenException', async () => {
       newUser.id = userId + 1;
       const dto = {
-        stock: 500
+        stock: 500,
       };
 
       try {
-        expect(await service.update(newUser, genericItem.id, dto)).toThrow(ForbiddenException);
+        expect(await service.update(newUser, genericItem.id, dto)).toThrow(
+          ForbiddenException,
+        );
       } catch (err) {
         expect(err.message).toEqual('Cannot execute "update" on "Item"');
       }
@@ -224,7 +237,9 @@ describe('ItemsService', () => {
       newUser.id = userId + 1;
 
       try {
-        expect(await service.delete(newUser, genericItem.id)).toThrow(ForbiddenException);
+        expect(await service.delete(newUser, genericItem.id)).toThrow(
+          ForbiddenException,
+        );
       } catch (err) {
         expect(err.message).toBe('Cannot execute "delete" on "Item"');
       }

--- a/src/items/services/items.service.spec.ts
+++ b/src/items/services/items.service.spec.ts
@@ -1,18 +1,236 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CaslAbilityFactory } from '../../auth/casl/casl-ability.factory';
+import { Brand } from '../../brands/entities/brands.entity';
+import { Category } from '../../categories/categories.entity';
+import { User } from '../../users/entities/user.entity';
+import { CreateItemDTO } from '../entities/create.item.dto';
+import { Item } from '../entities/items.entity';
 import { ItemsService } from './items.service';
 
 describe('ItemsService', () => {
   let service: ItemsService;
+  const newUser = new User();
+  const userId = 1;
+  newUser.id = userId;
+
+  const genericItem = {
+    id: 3,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    title: "Name 2",
+    description: "Des 2",
+    price: 2,
+    stock: 2,
+    brandId: new Brand(),
+    userId,
+    categoryId: new Category(),
+    cartItemsId: [],
+    questions: []
+  }
+
+  const mockItemsRepository = {
+    find: jest.fn(() => Promise.resolve([{
+      id: 2,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: "Name",
+      description: "Des",
+      price: 1,
+      stock: 1,
+      brandId: new Brand(),
+      userId: 1,
+      categoryId: new Category(),
+      cartItemsId: [],
+      questions: []
+    }, {
+      id: 3,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      title: "Name 2",
+      description: "Des 2",
+      price: 2,
+      stock: 2,
+      brandId: new Brand(),
+      userId: newUser.id,
+      categoryId: new Category(),
+      cartItemsId: [],
+      questions: []
+    }])),
+    findOne: jest.fn(id => Promise.resolve(genericItem)),
+    create: jest.fn(body => Object.assign(body, { id: 4 })),
+    merge: jest.fn((item, body) => Object.assign({ item, body })),
+    save: jest.fn(item => Promise.resolve(item)),
+    delete: jest.fn(id => Promise.resolve(true)),
+  }
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ItemsService],
-    }).compile();
+      providers: [
+        ItemsService,
+        {
+          provide: getRepositoryToken(Item),
+          useValue: mockItemsRepository,
+        },
+        CaslAbilityFactory
+      ]
+    })
+      .compile();
 
     service = module.get<ItemsService>(ItemsService);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('all', () => {
+    it('should return an array of Items', async () => {
+      expect(await service.findAll()).toEqual([{
+        id: 2,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name",
+        description: "Des",
+        price: 1,
+        stock: 1,
+        brandId: expect.any(Brand),
+        userId: 1,
+        categoryId: expect.any(Category),
+        cartItemsId: [],
+        questions: []
+      }, {
+        id: 3,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: expect.any(Brand),
+        userId: newUser.id,
+        categoryId: expect.any(Category),
+        cartItemsId: [],
+        questions: []
+      }]);
+    });
+  });
+
+  describe('one', () => {
+    it('should return an Item', async () => {
+      expect(await service.findOne(3)).toEqual({
+        id: 3,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: expect.any(Brand),
+        userId: newUser.id,
+        categoryId: expect.any(Category),
+        cartItemsId: [],
+        questions: []
+      });
+    });
+
+    it('should throw a NotFoundException', async () => {
+      mockItemsRepository.findOne.mockReturnValueOnce(null);
+
+      try {
+        expect(await service.findOne(10)).toThrow(NotFoundException);
+      } catch (err) {
+        expect(err.message).toBe('Item Not Found');
+      }
+    });
+  });
+
+  describe('create', () => {
+    it('should create a Item', async () => {
+      const dto: CreateItemDTO = {
+        title: "Name 2",
+        description: "Des 2",
+        price: 2,
+        stock: 2,
+        brandId: new Brand(),
+        categoryId: new Category(),
+      };
+
+      const expected = {
+        id: 4,
+        ...dto,
+        userId: newUser.id
+      };
+
+      expect(await service.create(newUser, dto)).toEqual(expected);
+
+      expect(mockItemsRepository.create).toHaveBeenCalledWith(dto);
+      expect(mockItemsRepository.save).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('update', () => {
+    it('should update an Item', async () => {
+      newUser.id = userId;
+      const dto = {
+        price: 100,
+        stock: 500
+      };
+
+      const expected = {
+        ...genericItem,
+        ...dto,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      };
+
+      mockItemsRepository.save.mockReturnValueOnce(Promise.resolve({ ...genericItem, ...dto }));
+
+      expect(await service.update(newUser, genericItem.id, dto)).toEqual(expected);
+
+      expect(mockItemsRepository.findOne).toHaveBeenCalledWith(genericItem.id);
+      expect(mockItemsRepository.merge).toHaveBeenCalledWith(genericItem, dto);
+    });
+
+    it('should throw ForbiddenException', async () => {
+      newUser.id = userId + 1;
+      const dto = {
+        stock: 500
+      };
+
+      try {
+        expect(await service.update(newUser, genericItem.id, dto)).toThrow(ForbiddenException);
+      } catch (err) {
+        expect(err.message).toEqual('Cannot execute "update" on "Item"');
+      }
+
+      expect(mockItemsRepository.findOne).toHaveBeenCalledWith(genericItem.id);
+      expect(mockItemsRepository.merge).toHaveBeenCalledTimes(1);
+      expect(mockItemsRepository.save).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('remove', () => {
+    it('should remove an Item', async () => {
+      newUser.id = userId;
+      expect(await service.delete(newUser, genericItem.id)).toEqual(true);
+
+      expect(mockItemsRepository.findOne).toHaveBeenCalledWith(genericItem.id);
+      expect(mockItemsRepository.delete).toHaveBeenCalled();
+    });
+
+    it('should throw ForbiddenException', async () => {
+      newUser.id = userId + 1;
+
+      try {
+        expect(await service.delete(newUser, genericItem.id)).toThrow(ForbiddenException);
+      } catch (err) {
+        expect(err.message).toBe('Cannot execute "delete" on "Item"');
+      }
+
+      expect(mockItemsRepository.findOne).toHaveBeenCalledWith(genericItem.id);
+      expect(mockItemsRepository.delete).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/items/services/items.service.ts
+++ b/src/items/services/items.service.ts
@@ -11,14 +11,13 @@ import { CaslAbilityFactory } from '../../auth/casl/casl-ability.factory';
 import { Permission } from '../../auth/permission.enum';
 import { ForbiddenError } from '@casl/ability';
 
-
 @Injectable()
 export class ItemsService {
   constructor(
     @InjectRepository(Item)
     private readonly ItemsRepo: Repository<Item>,
-    private readonly caslAbilityFactory: CaslAbilityFactory
-  ) { }
+    private readonly caslAbilityFactory: CaslAbilityFactory,
+  ) {}
 
   findAll(): Promise<Item[]> {
     return this.ItemsRepo.find();
@@ -43,7 +42,10 @@ export class ItemsService {
     const item = await this.findOne(id);
     const ability = this.caslAbilityFactory.createForUser(user);
 
-    ForbiddenError.from(ability).throwUnlessCan(Permission.Update, Object.assign(new Item(), item));
+    ForbiddenError.from(ability).throwUnlessCan(
+      Permission.Update,
+      Object.assign(new Item(), item),
+    );
 
     this.ItemsRepo.merge(item, body);
     return this.ItemsRepo.save(item);
@@ -53,7 +55,10 @@ export class ItemsService {
     const item = await this.findOne(id);
     const ability = this.caslAbilityFactory.createForUser(user);
 
-    ForbiddenError.from(ability).throwUnlessCan(Permission.Delete, Object.assign(new Item(), item));
+    ForbiddenError.from(ability).throwUnlessCan(
+      Permission.Delete,
+      Object.assign(new Item(), item),
+    );
 
     await this.ItemsRepo.delete(id);
     return true;

--- a/src/items/services/items.service.ts
+++ b/src/items/services/items.service.ts
@@ -1,13 +1,23 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Item } from '../entities/items.entity';
 import { Repository } from 'typeorm';
+
+import { Item } from '../entities/items.entity';
+import { User } from '../../users/entities/user.entity';
+
+import { CreateItemDTO } from '../entities/create.item.dto';
+
+import { CaslAbilityFactory } from '../../auth/casl/casl-ability.factory';
+import { Permission } from '../../auth/permission.enum';
+import { ForbiddenError } from '@casl/ability';
+
 
 @Injectable()
 export class ItemsService {
   constructor(
     @InjectRepository(Item)
     private readonly ItemsRepo: Repository<Item>,
+    private readonly caslAbilityFactory: CaslAbilityFactory
   ) { }
 
   findAll(): Promise<Item[]> {
@@ -15,20 +25,36 @@ export class ItemsService {
   }
 
   findOne(id: number): Promise<Item> {
-    return this.ItemsRepo.findOne(id);
+    const item = this.ItemsRepo.findOne(id);
+
+    if (!item) throw new NotFoundException('Item Not Found');
+
+    return item;
   }
 
-  create(body: any): Promise<Item> {
-    return this.ItemsRepo.save(body);
+  create(user: User, body: CreateItemDTO): Promise<Item> {
+    const item = this.ItemsRepo.create(body);
+    item.userId = user.id;
+
+    return this.ItemsRepo.save(item);
   }
 
-  async update(id: number, body: any): Promise<Item> {
+  async update(user: User, id: number, body: any): Promise<Item> {
     const item = await this.findOne(id);
+    const ability = this.caslAbilityFactory.createForUser(user);
+
+    ForbiddenError.from(ability).throwUnlessCan(Permission.Update, Object.assign(new Item(), item));
+
     this.ItemsRepo.merge(item, body);
     return this.ItemsRepo.save(item);
   }
 
-  async delete(id: number): Promise<boolean> {
+  async delete(user: User, id: number): Promise<boolean> {
+    const item = await this.findOne(id);
+    const ability = this.caslAbilityFactory.createForUser(user);
+
+    ForbiddenError.from(ability).throwUnlessCan(Permission.Delete, Object.assign(new Item(), item));
+
     await this.ItemsRepo.delete(id);
     return true;
   }


### PR DESCRIPTION
# Autorización Items

Solves #181 

- Se creó un __DTO__ para la petición de creación de un `Item`.
- Ahora el `controller` cuenta con una respuesta en caso de que ocurra un error en `service`.
- Se implementaron los __policies__, __permissions__ y __guard__ del ___auth___ y el módulo de `CASL`.
- Se realizaron los __test__ correspondientes.

## Service
<p align="center">
<img src="https://user-images.githubusercontent.com/76873353/148687750-5670641c-6939-44ff-857a-f02fc17f53ad.png">
</p>

## Controller
<p align="center">
<img src="https://user-images.githubusercontent.com/76873353/148687788-e5c6267f-5e36-4fba-9a63-797f6168bdd1.png">
</p>

## Issue
  Los métodos `can` y `cannot` de los objectos de tipo `Ability` son sumamente precisas y los retornos de objetos desde una DB no son inicializados (aparentemente) como sus correspondientes `Entity`, sino como `Object`, y al pasar dentro de estos métodos, no son reconocidos, haciendo que falle la autorización de permisos.

### HotFix
  La solución que encontré (la única que me funcionó luego de mucho intentar), es inicializar con el correspondiente objeto y pasar sus propiedades.

```typescript
const item: Item = this.ItemsRepo.findOne(id);

console.log( item instanceof Item ) // false 
console.log( item instanceof Object ) // true 
console.log( Object.assign(new Item(), item) instanceof Item ) // true 
```

  La implementación de un `DTO` tampoco resulta útil, ya que `ItemsRepo` no devuelve objetos inicializados como ese `DTO`.
