### PR TITLE
Fix 196 password validation

### DIFF
--- a/src/authentication/controllers/authentication.controller.ts
+++ b/src/authentication/controllers/authentication.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Req,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { AuthenticationService } from '../services/authentication.service';
 import { CreateUserDTO } from '../../users/entities/create-user-dto.entity';
 import { LocalAuthGuard } from '../guards/local-auth.guard';
@@ -10,10 +18,11 @@ export class AuthenticationController {
 
   @Public()
   @Post('register')
+  @UsePipes(new ValidationPipe({ disableErrorMessages: true }))
   async register(@Body() user: CreateUserDTO) {
     await this.authService.checkEmail(user);
 
-    await this.authService.checkPass(user.password);
+    // await this.authService.checkPass(user.password);
     //verificar max, min caracteres y alfanumerico y simbolos (regExp)
 
     await this.authService.create(user);

--- a/src/authentication/services/authentication.service.ts
+++ b/src/authentication/services/authentication.service.ts
@@ -24,30 +24,30 @@ export class AuthenticationService {
     }
   }
 
-  async checkPass(password: string) {
-    if (password.length > 16) {
-      throw new HttpException(
-        'Password must not contain more than 16 characters.',
-        HttpStatus.CONFLICT,
-      );
-    }
+  // async checkPass(password: string) {
+  //   if (password.length > 16) {
+  //     throw new HttpException(
+  //       'Password must not contain more than 16 characters.',
+  //       HttpStatus.CONFLICT,
+  //     );
+  //   }
 
-    if (password.length < 8) {
-      throw new HttpException(
-        'Password must contain at least 8 characters.',
-        HttpStatus.CONFLICT,
-      );
-    }
+  //   if (password.length < 8) {
+  //     throw new HttpException(
+  //       'Password must contain at least 8 characters.',
+  //       HttpStatus.CONFLICT,
+  //     );
+  //   }
 
-    //buscar expresión regular que funcione
-    // const regEx = /^[A-Za-z0-9\s!@#$%^&*()_+=-`~\\\]\[{}|';:/.,?><]*$/g;
-    // if (regEx.test(password)) {
-    //   throw new HttpException(
-    //     'The password can contain letters,numbers and special characters only.',
-    //     HttpStatus.CONFLICT,
-    //   );
-    // }
-  }
+  //   buscar expresión regular que funcione
+  //   const regEx = /^[A-Za-z0-9\s!@#$%^&*()_+=-`~\\\]\[{}|';:/.,?><]*$/g;
+  //   if (regEx.test(password)) {
+  //     throw new HttpException(
+  //       'The password can contain letters,numbers and special characters only.',
+  //       HttpStatus.CONFLICT,
+  //     );
+  //   }
+  // }
 
   async create(user: CreateUserDTO) {
     user.email = user.email.toLowerCase();

--- a/src/users/entities/create-user-dto.entity.ts
+++ b/src/users/entities/create-user-dto.entity.ts
@@ -1,5 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEmail, IsString } from 'class-validator';
+import {
+  IsEmail,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 export class CreateUserDTO {
   @ApiProperty({
@@ -7,6 +13,9 @@ export class CreateUserDTO {
     type: String,
   })
   @IsString()
+  @MinLength(8)
+  @MaxLength(16)
+  @Matches(/^(?=.*[0-9])(?=.*[!@#$%^&*])[a-z0-9!@#$%^&*]/)
   password: string;
 
   @ApiProperty({


### PR DESCRIPTION
## Se agregaron las validaciones con pipes para la contraseña de user.

## 📝 Resumen:
- Se agregó el uso de pipe en el controlador de autenticación (en el endpoint de `register`).
- Se agregó los decoradores para validar la contraseña en el DTO de crear usuario.
- Se comentó los métodos y el llamado al mismo del controlador y el servicio de `authentication`

## 📸  Screenshots:
### La contraseña tiene que ser mayor de 8 caracteres (da error porque tiene menos):
![Screenshot from 2022-01-11 12-21-30](https://user-images.githubusercontent.com/78811265/148972280-954e7fed-b167-4e85-afe5-83fd68082fcd.png)
---
### La contraseña tiene que ser menor a 16 caracteres (da error porque tiene más):
![Screenshot from 2022-01-11 12-22-42](https://user-images.githubusercontent.com/78811265/148972432-8c597df0-4fef-4c1e-a3d7-fdb614adb063.png)
---
### La contraseña tiene que tener un símbolo (da error porque no lo tiene):
![Screenshot from 2022-01-11 12-22-13](https://user-images.githubusercontent.com/78811265/148972307-0c2e781e-70ac-4335-8d24-5a0af1210771.png)
![Screenshot from 2022-01-11 12-23-05](https://user-images.githubusercontent.com/78811265/148972542-9648ce9b-8a42-476d-930b-22e2ef76260d.png)
---
### La contraseña también tiene que tener un número o letra (da error porque solo tiene símbolos)
![Screenshot from 2022-01-11 12-23-36](https://user-images.githubusercontent.com/78811265/148972688-2af43d85-9d0d-4946-9f8d-cf96b0516d89.png)
---
## En este caso la contraseña sí cumple con todos los requisitos:
![Screenshot from 2022-01-11 12-23-52](https://user-images.githubusercontent.com/78811265/148972825-85e65e91-db4d-49c2-9863-13a46e0291d0.png)



