### PR TITLE
use real user instead of mock in PoliciesGuard

### DIFF
--- a/src/auth/guards/policies.guard.ts
+++ b/src/auth/guards/policies.guard.ts
@@ -1,6 +1,5 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
-import { User } from '../../users/entities/user.entity';
 import { CHECK_POLICIES_KEY } from '../constants/check-policies.constant';
 import { CaslAbilityFactory, AppAbility } from '../casl/casl-ability.factory';
 import { PolicyHandler } from '../types/policy-handler.type';
@@ -19,9 +18,12 @@ export class PoliciesGuard implements CanActivate {
         context.getHandler(),
       ) || [];
 
-    // const { user } = context.switchToHttp().getRequest();
-    const user = new User();
-    user.id = 123;
+    const { user } = context.switchToHttp().getRequest();
+
+    if (!user) {
+      return false;
+    }
+
     const ability = this.caslAbilityFactory.createForUser(user);
 
     return policyHandlers.every((handler) =>


### PR DESCRIPTION
Closes #209 

Lo unico que hice fue sacar el mock que habia en PoliciesGuard y usar el usuario real que viene de la autenticacion.

Unit tests:
![image](https://user-images.githubusercontent.com/58740322/149257827-d769e465-0837-4e4b-bc24-cd9b37311e2e.png)

`console.log` que hice para comprobar que le usuario estuviese correcto
![image](https://user-images.githubusercontent.com/58740322/149258593-20bed026-fbbe-46c6-bd06-2addd8258be1.png)
