### PR TITLE
Refactored default dates

### DIFF
--- a/src/addresses/entities/address.entity.ts
+++ b/src/addresses/entities/address.entity.ts
@@ -35,7 +35,6 @@ export class Address {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 
@@ -49,7 +48,6 @@ export class Address {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   updatedAt: Date;
 

--- a/src/addresses/entities/address.entity.ts
+++ b/src/addresses/entities/address.entity.ts
@@ -1,12 +1,11 @@
-import { Type } from '@nestjs/common';
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
-  UpdateDateColumn,
   DeleteDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 
 @Entity({

--- a/src/cart-item/entities/cart-item.entity.ts
+++ b/src/cart-item/entities/cart-item.entity.ts
@@ -1,11 +1,11 @@
 import {
-  Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
-  UpdateDateColumn,
-  ManyToOne,
+  Entity,
   JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 

--- a/src/cart-item/entities/cart-item.entity.ts
+++ b/src/cart-item/entities/cart-item.entity.ts
@@ -56,7 +56,6 @@ export class CartItem {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   @ApiProperty({
@@ -71,7 +70,6 @@ export class CartItem {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   @ApiProperty({

--- a/src/cart/entities/cart.entity.ts
+++ b/src/cart/entities/cart.entity.ts
@@ -1,14 +1,18 @@
-import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
 import {
-  Entity,
+  ApiHideProperty,
+  ApiProperty
+} from '@nestjs/swagger';
+import {
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
-  UpdateDateColumn,
-  ManyToOne,
+  Entity,
   JoinColumn,
+  ManyToOne,
   OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
 } from 'typeorm';
+
 import { CartItem } from '../../cart-item/entities/cart-item.entity';
 import { User } from '../../users/entities/user.entity';
 

--- a/src/cart/entities/cart.entity.ts
+++ b/src/cart/entities/cart.entity.ts
@@ -30,7 +30,6 @@ export class Cart {
     name: 'created_at',
     nullable: false,
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     select: false,
   })
   @ApiHideProperty()
@@ -40,7 +39,6 @@ export class Cart {
     name: 'updated_at',
     nullable: false,
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     select: false,
   })
   @ApiHideProperty()

--- a/src/custom-messages/entities/custom-messages.entity.ts
+++ b/src/custom-messages/entities/custom-messages.entity.ts
@@ -42,7 +42,6 @@ export class CustomMessage {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @ApiProperty({ example: '2016-03-26 10:10:10-05:00', description: "Message's creation date" })
   createdAt: Date;
@@ -50,7 +49,6 @@ export class CustomMessage {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @ApiProperty({ example: '2016-03-26 10:10:10-05:00', description: "Message's last update date" })
   updatedAt: Date;

--- a/src/custom-messages/entities/custom-messages.entity.ts
+++ b/src/custom-messages/entities/custom-messages.entity.ts
@@ -1,6 +1,15 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, DeleteDateColumn, JoinColumn } from 'typeorm';
-
+import {
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
 import { ApiProperty } from "@nestjs/swagger";
+
 import { User } from '../../users/entities/user.entity';
 
 @Entity('custom_messages')

--- a/src/deliveries/entities/delivery.entity.ts
+++ b/src/deliveries/entities/delivery.entity.ts
@@ -2,10 +2,11 @@ import { ApiProperty } from '@nestjs/swagger';
 import {
   Entity,
   Column,
-  PrimaryGeneratedColumn,
   CreateDateColumn,
+  PrimaryGeneratedColumn,
   UpdateDateColumn,
 } from 'typeorm';
+
 import DeliveryStatus from './delivery-status.enum';
 
 @Entity({

--- a/src/deliveries/entities/delivery.entity.ts
+++ b/src/deliveries/entities/delivery.entity.ts
@@ -33,7 +33,6 @@ export class Delivery {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 
@@ -47,7 +46,6 @@ export class Delivery {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   updatedAt: Date;
 

--- a/src/favorites/entities/favorite.entity.ts
+++ b/src/favorites/entities/favorite.entity.ts
@@ -60,7 +60,6 @@ export class Favorite {
     name: 'updated_at',
     type: 'timestamptz',
     nullable: false,
-    default: () => 'CURRENT_TIMESTAMP',
   })
   updated_at: Date;
 }

--- a/src/favorites/entities/favorite.entity.ts
+++ b/src/favorites/entities/favorite.entity.ts
@@ -1,13 +1,12 @@
 import {
   Entity,
-  Column,
+  JoinColumn,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
-  JoinColumn,
 } from 'typeorm';
-
-import { ManyToOne } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+import { ManyToOne } from 'typeorm';
+
 import { User } from '../../users/entities/user.entity';
 import { Item } from '../../items/entities/items.entity';
 

--- a/src/history/models/history.entity.ts
+++ b/src/history/models/history.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, ManyToOne, DeleteDateColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, ManyToOne, DeleteDateColumn, CreateDateColumn } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { User } from '../../users/entities/user.entity';
 import { Item } from '../../items/entities/items.entity';
@@ -38,10 +38,9 @@ export class History {
     description: 'The date-time that was created',
     nullable: false,
   })
-  @Column({
+  @CreateDateColumn({
     name: 'created_at',
     type: 'timestamp',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;

--- a/src/history/models/history.entity.ts
+++ b/src/history/models/history.entity.ts
@@ -1,7 +1,15 @@
-import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, ManyToOne, DeleteDateColumn, CreateDateColumn } from 'typeorm';
+import {
+  Entity,
+  CreateDateColumn,
+  DeleteDateColumn,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from '../../users/entities/user.entity';
+
 import { Item } from '../../items/entities/items.entity';
+import { User } from '../../users/entities/user.entity';
 
 @Entity('history')
 export class History {

--- a/src/items/entities/items.entity.ts
+++ b/src/items/entities/items.entity.ts
@@ -39,7 +39,7 @@ export class Item {
   @ApiProperty({
     example: '2016-03-26 10:10:10-05:00',
     description: "Item's creation date",
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
   })
@@ -50,7 +50,7 @@ export class Item {
     type: 'timestamptz',
   })
   @ApiProperty({
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2016-03-26 10:10:10-05:00',

--- a/src/items/entities/items.entity.ts
+++ b/src/items/entities/items.entity.ts
@@ -35,7 +35,6 @@ export class Item {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @ApiProperty({
     example: '2016-03-26 10:10:10-05:00',
@@ -49,7 +48,6 @@ export class Item {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @ApiProperty({
     default: () => 'CURRENT_TIMESTAMP',

--- a/src/items/entities/items.entity.ts
+++ b/src/items/entities/items.entity.ts
@@ -8,8 +8,8 @@ import {
   JoinColumn,
   OneToMany,
 } from 'typeorm';
-
 import { ApiProperty } from '@nestjs/swagger';
+
 import { User } from '../../users/entities/user.entity';
 import { Brand } from '../../brands/entities/brands.entity';
 import { Category } from '../../categories/entities/categories.entity';

--- a/src/offers/entities/offer.entity.ts
+++ b/src/offers/entities/offer.entity.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import {
   Column,
+  CreateDateColumn,
   Entity,
   JoinColumn,
   ManyToOne,
@@ -29,10 +30,9 @@ export class Offer {
     description: 'Created date',
     example: '2021-10-19 10:23:54+03'
   })
-  @Column({
+  @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 

--- a/src/payment-methods/models/payment-method.entity.ts
+++ b/src/payment-methods/models/payment-method.entity.ts
@@ -1,6 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
-import { type } from 'os';
 import {
   Entity,
   Column,

--- a/src/payment-methods/models/payment-method.entity.ts
+++ b/src/payment-methods/models/payment-method.entity.ts
@@ -63,7 +63,6 @@ export default class PaymentMethod {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @Exclude({ toPlainOnly: true })
   created_at: Date;
@@ -77,7 +76,6 @@ export default class PaymentMethod {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   @Exclude({ toPlainOnly: true })
   updated_at: Date;

--- a/src/payments/entities/payment.entity.ts
+++ b/src/payments/entities/payment.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+
 import PaymentStatus from './payment-status.enum';
 
 @Entity({

--- a/src/payments/entities/payment.entity.ts
+++ b/src/payments/entities/payment.entity.ts
@@ -33,7 +33,6 @@ export class Payment {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 
@@ -47,7 +46,6 @@ export class Payment {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   updatedAt: Date;
 

--- a/src/photos/models/photos.entity.ts
+++ b/src/photos/models/photos.entity.ts
@@ -1,8 +1,11 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn
+} from 'typeorm';
 import { PolymorphicChildInterface } from 'typeorm-polymorphic/dist/polymorphic.interface';
-import { PolymorphicParent } from 'typeorm-polymorphic';
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from '../../users/entities/user.entity';
 
 @Entity({ name: 'photos' })
 export class PhotosEntity implements PolymorphicChildInterface {

--- a/src/photos/models/photos.entity.ts
+++ b/src/photos/models/photos.entity.ts
@@ -23,7 +23,7 @@ export class PhotosEntity implements PolymorphicChildInterface {
     type: Date,
     format: 'date-time',
     description: 'Creation date',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   @CreateDateColumn({

--- a/src/photos/models/photos.entity.ts
+++ b/src/photos/models/photos.entity.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
 import { PolymorphicChildInterface } from 'typeorm-polymorphic/dist/polymorphic.interface';
 import { PolymorphicParent } from 'typeorm-polymorphic';
 import { ApiProperty } from '@nestjs/swagger';
@@ -26,10 +26,9 @@ export class PhotosEntity implements PolymorphicChildInterface {
     default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
-  @Column({
+  @CreateDateColumn({
     type: 'timestamp with time zone',
     name: 'created_at',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;

--- a/src/platform/entities/platform.entity.ts
+++ b/src/platform/entities/platform.entity.ts
@@ -35,7 +35,6 @@ export class Platform {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;
@@ -51,7 +50,6 @@ export class Platform {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   updatedAt: Date;

--- a/src/platform/entities/update-platform-dto.entity.ts
+++ b/src/platform/entities/update-platform-dto.entity.ts
@@ -7,7 +7,6 @@ export class UpdatePlatformDTO {
   @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
   })
   updatedAt?: Date;
 

--- a/src/questions/entities/question.entity.ts
+++ b/src/questions/entities/question.entity.ts
@@ -2,17 +2,18 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  DeleteDateColumn,
+  JoinColumn,
   ManyToOne,
   OneToOne,
-  JoinColumn,
   PrimaryGeneratedColumn,
-  DeleteDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
-import { User } from '../../users/entities/user.entity';
 import { Answer } from './answer.entity';
 import { Type } from 'class-transformer';
+
 import { Item } from '../../items/entities/items.entity';
+import { User } from '../../users/entities/user.entity';
 
 @Entity('questions')
 export class Question {

--- a/src/questions/entities/question.entity.ts
+++ b/src/questions/entities/question.entity.ts
@@ -79,7 +79,7 @@ export class Question {
 
   @ApiProperty({
     description: 'The date when question has been created',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/questions/entities/question.entity.ts
+++ b/src/questions/entities/question.entity.ts
@@ -89,7 +89,6 @@ export class Question {
     name: 'created_at',
     type: 'timestamptz',
     nullable: false,
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -54,7 +54,6 @@ export class Search {
     name: 'created_at',
     type: 'timestamptz',
     nullable: false,
-    default: () => 'CURRENT_TIMESTAMP',
   })
   createdAt: Date;
 }

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -7,6 +7,7 @@ import {
   ManyToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
+
 import { User } from '../../users/entities/user.entity';
 
 @Entity('searches')
@@ -44,7 +45,7 @@ export class Search {
 
   @ApiProperty({
     description: 'The timestamp of the creation',
-    default: 'CURRENT_TIMESTAMP',
+    default: () => 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/search/entities/search.entity.ts
+++ b/src/search/entities/search.entity.ts
@@ -44,7 +44,7 @@ export class Search {
 
   @ApiProperty({
     description: 'The timestamp of the creation',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/stores/entities/stores.entity.ts
+++ b/src/stores/entities/stores.entity.ts
@@ -30,7 +30,7 @@ export class Store {
     format: 'date-time',
     description: 'Created date',
     example: '2021-11-26T20:24:45.386Z',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   @CreateDateColumn({

--- a/src/stores/entities/stores.entity.ts
+++ b/src/stores/entities/stores.entity.ts
@@ -4,6 +4,8 @@ import {
   JoinColumn,
   PrimaryGeneratedColumn,
   OneToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Brand } from '../../brands/entities/brands.entity';
@@ -31,10 +33,9 @@ export class Store {
     default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
-  @Column({
+  @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;
@@ -46,10 +47,9 @@ export class Store {
     example: '2021-11-26T20:24:45.386Z',
     readOnly: true,
   })
-  @Column({
+  @UpdateDateColumn({
     name: 'updated_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   updatedAt: Date;

--- a/src/stores/entities/stores.entity.ts
+++ b/src/stores/entities/stores.entity.ts
@@ -1,13 +1,14 @@
 import {
   Column,
+  CreateDateColumn,
   Entity,
   JoinColumn,
   PrimaryGeneratedColumn,
   OneToOne,
-  CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+
 import { Brand } from '../../brands/entities/brands.entity';
 import { User } from '../../users/entities/user.entity';
 

--- a/src/support/entities/supportCategory.entity.ts
+++ b/src/support/entities/supportCategory.entity.ts
@@ -23,7 +23,7 @@ export class SupportCategory {
 
   @ApiProperty({
     description: 'The date when has been created',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/support/entities/supportCategory.entity.ts
+++ b/src/support/entities/supportCategory.entity.ts
@@ -32,7 +32,6 @@ export class SupportCategory {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;

--- a/src/support/entities/supportCategory.entity.ts
+++ b/src/support/entities/supportCategory.entity.ts
@@ -1,11 +1,12 @@
 import {
+  Column,
+  CreateDateColumn,
   Entity,
   PrimaryGeneratedColumn,
-  Column,
   OneToMany,
-  CreateDateColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+
 import { SupportQuestion } from './supportQuestion.entity';
 
 @Entity('support_categories')

--- a/src/support/entities/supportQuestion.entity.ts
+++ b/src/support/entities/supportQuestion.entity.ts
@@ -29,7 +29,7 @@ export class SupportQuestion {
 
   @ApiProperty({
     description: 'The date when has been created',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/support/entities/supportQuestion.entity.ts
+++ b/src/support/entities/supportQuestion.entity.ts
@@ -38,7 +38,6 @@ export class SupportQuestion {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;

--- a/src/support/entities/supportQuestion.entity.ts
+++ b/src/support/entities/supportQuestion.entity.ts
@@ -1,12 +1,13 @@
 import {
-  Entity,
-  PrimaryGeneratedColumn,
   Column,
-  ManyToOne,
-  JoinColumn,
   CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+
 import { SupportCategory } from './supportCategory.entity';
 
 /**

--- a/src/support/entities/supportRequest.entity.ts
+++ b/src/support/entities/supportRequest.entity.ts
@@ -38,7 +38,6 @@ export class SupportRequest {
   @CreateDateColumn({
     name: 'created_at',
     type: 'timestamptz',
-    default: () => 'CURRENT_TIMESTAMP',
     nullable: false,
   })
   createdAt: Date;

--- a/src/support/entities/supportRequest.entity.ts
+++ b/src/support/entities/supportRequest.entity.ts
@@ -29,7 +29,7 @@ export class SupportRequest {
 
   @ApiProperty({
     description: 'The date when has been created',
-    default: () => 'CURRENT_TIMESTAMP',
+    default: 'CURRENT_TIMESTAMP',
     type: Date,
     format: 'date-time',
     example: '2021-11-18T01:46:52.589Z',

--- a/src/support/entities/supportRequest.entity.ts
+++ b/src/support/entities/supportRequest.entity.ts
@@ -1,13 +1,14 @@
 import {
-  Entity,
-  PrimaryGeneratedColumn,
   Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
   ManyToOne,
   OneToOne,
-  JoinColumn,
-  CreateDateColumn,
+  PrimaryGeneratedColumn,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
+
 import { User } from '../../users/entities/user.entity';
 
 /**


### PR DESCRIPTION
## Refactored default values of date column in all entities.

### Summary:

#### Refactor:
- Removed default property in date column decorators.
- Replaced ```() => 'CURRENT_TIMESTAMP'``` by ```'CURRENT_TIMESTAMP'``` in swagger decorators.
- Removed unnecessary imports.
- Reformatted import sentences.

## Screenshots:
```POST /stores/``` - When creating a new store, the value of ```created_at``` column is generated automatically.
```PATCH /stores/``` - When updating a store, the value of ```updated_at``` column is updated automatically.

![default_dates](https://user-images.githubusercontent.com/54417420/149387805-06c19169-bcac-4e45-8b28-8c469bc849d5.gif)
