### PR TITLE
Fix public decorator

### DIFF
--- a/src/authentication/guards/jwt-auth.guard.ts
+++ b/src/authentication/guards/jwt-auth.guard.ts
@@ -18,7 +18,11 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       context.getHandler(),
       context.getClass(),
     ]);
-    if (isPublic) {
+
+    const authorization = context.switchToHttp().getRequest()
+      .headers.authorization;
+
+    if (isPublic && !authorization) {
       return true;
     }
     return super.canActivate(context);

--- a/src/authentication/strategies/local.strategy.ts
+++ b/src/authentication/strategies/local.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy } from 'passport-local';
 import { AuthenticationService } from '../services/authentication.service';


### PR DESCRIPTION
Problem: when @Public() decorator was used, the request never returned the user when authentication was being pass through headers.

Solution: introduce validation in the execution context, to verify in Authorization is being passed.

![image](https://user-images.githubusercontent.com/18199281/149524132-bb1872e5-964f-429d-bdb8-9668d6abda50.png)

![image](https://user-images.githubusercontent.com/18199281/149524252-485edb83-2560-46f5-84c5-deb70d40ab92.png)
