### PR TITLE
Auth items fix entity

### DIFF
--- a/src/items/entities/items.entity.ts
+++ b/src/items/entities/items.entity.ts
@@ -114,7 +114,7 @@ export class Item {
 
   @ManyToOne(() => Brand)
   @JoinColumn({
-    name: 'brand',
+    name: 'brand_id',
   })
   @ApiProperty({
     type: Brand,


### PR DESCRIPTION
# HotFix
- La `Entity` en lugar de relacionar su propiedad `brand` con `brand_id` del __schema__, lo hacía con `brand`.