### PR TITLE
Auth items fix entity

### DIFF
--- a/src/auth/casl/casl-ability.factory.ts
+++ b/src/auth/casl/casl-ability.factory.ts
@@ -27,7 +27,7 @@ export class CaslAbilityFactory {
     // can<FlatClass<[CLASE]>>(Permission[PERMISO], [CLASE], { 'user.id': user.id });
     can([Permission.Create, Permission.Read], Item);
     can<FlatClass<Item>>([Permission.Delete, Permission.Update], Item, {
-      'user.id': Number(user.id),
+      'user.id': user.id
     });
 
     can<FlatClass<CustomMessage>>([Permission.Read, Permission.Delete, Permission.Update], CustomMessage, { "user.id": user.id });

--- a/src/items/controllers/items.controller.ts
+++ b/src/items/controllers/items.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiBearerAuth,
   ApiQuery,
   ApiUnauthorizedResponse,
+  ApiBody,
 } from '@nestjs/swagger';
 
 import { ItemsService } from '../services/items.service';
@@ -33,6 +34,8 @@ import { subject } from '@casl/ability';
 import { CaslAbilityFactory } from '../../auth/casl/casl-ability.factory';
 import { Request } from 'express';
 import { Public } from '../../authentication/decorators/public.decorator';
+import { CreateItemDTO } from '../entities/create.item.dto';
+import { UpdateItemDTO } from '../entities/update.item.dto';
 
 @ApiTags('Items')
 @ApiBearerAuth()
@@ -141,6 +144,9 @@ export class ItemsController {
   }
 
   @ApiOperation({ summary: 'Create a item' })
+  @ApiBody({
+    type: CreateItemDTO,
+  })
   @ApiResponse({
     status: 201,
     description: 'The created item',
@@ -154,13 +160,16 @@ export class ItemsController {
   })
   @Post()
   @HttpCode(201)
-  create(@Req() req: Request, @Body() body: any): Promise<Item> {
+  create(@Req() req: Request, @Body() body: CreateItemDTO): Promise<Item> {
     const user: any = req.user;
 
     return this.ItemsService.create(user, body);
   }
 
   @ApiOperation({ summary: 'Update a item by ID' })
+  @ApiBody({
+    type: UpdateItemDTO,
+  })
   @ApiResponse({
     status: 204,
     description: 'The updated item',
@@ -180,7 +189,11 @@ export class ItemsController {
   @ApiNotFoundResponse({
     description: 'Item Not Found',
   })
-  async update(@Req() req: Request, @Param('id') id: number, @Body() body: any): Promise<Item> {
+  async update(
+    @Req() req: Request,
+    @Param('id') id: number,
+    @Body() body: UpdateItemDTO,
+  ): Promise<Item> {
     const user: any = req.user;
 
     const item = await this.ItemsService.findOne(id);

--- a/src/items/entities/create.item.dto.ts
+++ b/src/items/entities/create.item.dto.ts
@@ -1,11 +1,47 @@
-import { Brand } from '../../brands/entities/brands.entity';
-import { Category } from '../../categories/entities/categories.entity';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class CreateItemDTO {
+  @IsString()
+  @ApiProperty({
+    type: String,
+    description: "Item's title"
+  })
   title: string;
+
+  @IsString()
+  @ApiProperty({
+    type: String,
+    description: "Item's description"
+  })
   description: string;
+
+  @IsNumber()
+  @ApiProperty({
+    type: Number,
+    description: "Item's price"
+  })
   price: number;
+
+  @IsNumber()
+  @ApiProperty({
+    type: Number,
+    description: "Item's current stock"
+  })
   stock: number;
-  brandId: Brand;
-  categoryId: Category;
+
+  @IsNumber()
+  @IsOptional()
+  @ApiProperty({
+    type: Number,
+    description: "Item's brand"
+  })
+  brand?: number;
+
+  @IsNumber()
+  @ApiProperty({
+    type: Number,
+    description: "Item's category"
+  })
+  category: number;
 }

--- a/src/items/entities/update.item.dto.ts
+++ b/src/items/entities/update.item.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateItemDTO } from './create.item.dto';
+
+export class UpdateItemDTO extends PartialType(CreateItemDTO) {} 

--- a/src/items/services/items.service.ts
+++ b/src/items/services/items.service.ts
@@ -13,6 +13,7 @@ import {
 } from 'nestjs-typeorm-paginate';
 import { User } from '../../users/entities/user.entity';
 import { CreateItemDTO } from '../entities/create.item.dto';
+import { UpdateItemDTO } from '../entities/update.item.dto';
 
 interface ItemSearchOptions {
   sellerId?: number;
@@ -86,14 +87,14 @@ export class ItemsService {
   }
 
   create(user: User, body: CreateItemDTO): Promise<Item> {
-    const item = this.ItemsRepo.create(body);
+    const item = this.ItemsRepo.create(<Item>(body as any));
     item.user = user;
 
     return this.ItemsRepo.save(item);
   }
 
-  async update(item: Item, body: any): Promise<Item> {
-    this.ItemsRepo.merge(item, body);
+  async update(item: Item, body: UpdateItemDTO): Promise<Item> {
+    this.ItemsRepo.merge(item, <Item>(body as any));
     return this.ItemsRepo.save(item);
   }
 


### PR DESCRIPTION
> Este PR no es urgente, ya que no soluciona ningún error que tire abajo la aplicación.
- Ahora se pueden pasar parámetros por `Body` desde __Swagger__.
- Se crearon / modificaron y documentaron los `DTO` correspondientes a `POST` y `PATCH`
- Había un error dentro de las reglas de CASL, donde se transformaban los `user.id` a tipo `Number`